### PR TITLE
:sparkles: Add `Snapshot.ignore(String... paths)` method

### DIFF
--- a/src/main/java/io/github/jsonSnapshot/Snapshot.java
+++ b/src/main/java/io/github/jsonSnapshot/Snapshot.java
@@ -1,11 +1,13 @@
 package io.github.jsonSnapshot;
 
+import lombok.Getter;
 import org.assertj.core.util.diff.DiffUtils;
 import org.assertj.core.util.diff.Patch;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -19,6 +21,7 @@ public class Snapshot {
 
     private Function<Object, String> jsonFunction;
 
+    @Getter
     private Object[] current;
 
     Snapshot(SnapshotFile snapshotFile, Class clazz, Method method, Function<Object, String> jsonFunction, Object... current) {
@@ -75,5 +78,22 @@ public class Snapshot {
 
     public String getSnapshotName() {
         return clazz.getName() + "." + method.getName() + "=";
+    }
+
+    /**
+     * Ignore nested fields in the {@link #current} objects.
+     *
+     * @param pathsToIgnore Dot delimited paths to ignore within the {@link #current} objects. For example {@code nested.field}.
+     * @return self
+     * @throws SnapshotMatchException if the {@link #current} objects are not nested {@link Map}s.
+     */
+    public Snapshot ignoring(String... pathsToIgnore) throws SnapshotMatchException {
+        for (String path : pathsToIgnore) {
+            for (Object object : current) {
+                SnapshotUtils.deleteNestedFieldFromMap(object, path);
+            }
+        }
+
+        return this;
     }
 }

--- a/src/main/java/io/github/jsonSnapshot/SnapshotUtils.java
+++ b/src/main/java/io/github/jsonSnapshot/SnapshotUtils.java
@@ -4,9 +4,11 @@ import org.mockito.ArgumentCaptor;
 
 import java.lang.reflect.Parameter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
@@ -81,5 +83,33 @@ public class SnapshotUtils {
         }
 
         return result;
+    }
+
+    public static void deleteNestedFieldFromMap(Object object, String path) {
+        deleteNestedFieldFromMap(object, Arrays.asList(path.split("\\.")));
+    }
+
+    private static void deleteNestedFieldFromMap(Object object, List<String> pathSegments) {
+        if (!(object instanceof Map)) {
+            throw new SnapshotMatchException("object is not a map");
+        }
+
+        Map map = (Map) object;
+        int numberOfSegments = pathSegments.size();
+
+        if (numberOfSegments == 0) {
+            return;
+        }
+
+        String key = pathSegments.get(0);
+
+        if (numberOfSegments == 1) {
+            if (map.containsKey(key)) {
+                map.put(key, "IGNORED");
+            }
+            return;
+        }
+
+        deleteNestedFieldFromMap(map.get(key), pathSegments.subList(1, numberOfSegments));
     }
 }

--- a/src/test/resources/ignoreFieldsExpected.json
+++ b/src/test/resources/ignoreFieldsExpected.json
@@ -1,0 +1,8 @@
+{
+  "topLevel": "IGNORED",
+  "nested": {
+    "field": "IGNORED",
+    "notIgnored": "unchanged"
+  },
+  "notIgnored": "unchanged"
+}

--- a/src/test/resources/ignoreFieldsOriginal.json
+++ b/src/test/resources/ignoreFieldsOriginal.json
@@ -1,0 +1,8 @@
+{
+  "topLevel": "X",
+  "nested": {
+    "field": "Y",
+    "notIgnored": "unchanged"
+  },
+  "notIgnored": "unchanged"
+}


### PR DESCRIPTION
- Restricted to nested `java.util.Map` objects.
- Technically replaces the nested value with `"IGNORE"` if it is present.