### PR TITLE
[JUnit5] support package-private test methods + minor refactoring

### DIFF
--- a/src/test/java/io/github/jsonSnapshot/SnapshotIntegrationTest.java
+++ b/src/test/java/io/github/jsonSnapshot/SnapshotIntegrationTest.java
@@ -13,37 +13,37 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class SnapshotIntegrationTest {
 
     @BeforeAll
-    public static void beforeAll() {
+    static void beforeAll() {
         start();
     }
 
     @AfterAll
-    public static void afterAll() {
+    static void afterAll() {
         validateSnapshots();
     }
 
     @Test
-    public void shouldMatchSnapshotOne() {
+    void shouldMatchSnapshotOne() {
         expect(FakeObject.builder().id("anyId1").value(1).name("anyName1").build()).toMatchSnapshot();
     }
 
     @Test
-    public void shouldMatchSnapshotTwo() {
+    void shouldMatchSnapshotTwo() {
         expect(FakeObject.builder().id("anyId2").value(2).name("anyName2").build()).toMatchSnapshot();
     }
 
     @Test
-    public void shouldMatchSnapshotThree() {
+    void shouldMatchSnapshotThree() {
         expect(FakeObject.builder().id("anyId3").value(3).name("anyName3").build()).toMatchSnapshot();
     }
 
     @Test
-    public void shouldMatchSnapshotFour() {
+    void shouldMatchSnapshotFour() {
         expect(FakeObject.builder().id("anyId4").value(4).name("any\n\n\nName4").build()).toMatchSnapshot();
     }
 
     @Test
-    public void shouldMatchSnapshotInsidePrivateMethod() {
+    void shouldMatchSnapshotInsidePrivateMethod() {
         matchInsidePrivate();
     }
 
@@ -52,13 +52,13 @@ public class SnapshotIntegrationTest {
     }
 
     @Test
-    public void shouldThrowSnapshotMatchException() {
+    void shouldThrowSnapshotMatchException() {
         assertThrows(SnapshotMatchException.class, expect(FakeObject.builder().id("anyId5").value(6).name("anyName5").build())::toMatchSnapshot, "Error on: \n" +
                 "io.github.jsonSnapshot.SnapshotIntegrationTest.shouldThrowSnapshotMatchException=[");
     }
 
     @Test
-    public void shouldThrowStackOverflowError() {
+    void shouldThrowStackOverflowError() {
         // Create cycle JSON
         FakeObject fakeObject1 = FakeObject.builder().id("anyId1").value(1).name("anyName1").build();
         FakeObject fakeObject2 = FakeObject.builder().id("anyId2").value(2).name("anyName2").build();


### PR DESCRIPTION
Addresses #13 

Fixed `SnapshotMatcher#getMethod` to use recursive lookup via `Class#getDeclaredMethod` rather than checking via `Class#getMethod` (which includes only public methods).

Did some code cleanup in related methods as well.